### PR TITLE
Pluggable CSS Parser fixes

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -3,10 +3,17 @@ Manifest.txt
 README.txt
 Rakefile
 example.rb
+inline-style.gemspec
 lib/inline-style.rb
+lib/inline-style/css_parsers.rb
+lib/inline-style/css_parsers/css_parser.rb
+lib/inline-style/css_parsers/csspool.rb
+lib/inline-style/mail/interceptor.rb
 lib/inline-style/rack/middleware.rb
 spec/as_middleware_spec.rb
 spec/css_inlining_spec.rb
+spec/css_parsers_spec.rb
+spec/factory_spec.rb
 spec/fixtures/all.css
 spec/fixtures/boletin.html
 spec/fixtures/box-model.html
@@ -15,4 +22,5 @@ spec/fixtures/none.css
 spec/fixtures/print.css
 spec/fixtures/selectors.html
 spec/fixtures/style.css
+spec/interceptor_spec.rb
 spec/spec_helper.rb

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,6 @@ $hoe = Hoe.spec('inline-style') do |p|
   p.rubyforge_name       = p.name
   p.extra_deps         = [
     ['nokogiri','>= 1.3.3'],
-    ['maca-fork-csspool', '>= 2.0.2']
   ]
   p.extra_dev_deps = [
     ['newgem', ">= #{::Newgem::VERSION}"],

--- a/inline-style.gemspec
+++ b/inline-style.gemspec
@@ -2,11 +2,11 @@
 
 Gem::Specification.new do |s|
   s.name = %q{inline-style}
-  s.version = "0.4.2.20110215202625"
+  s.version = "0.4.2.20110217201008"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Macario Ortega"]
-  s.date = %q{2011-02-15}
+  s.date = %q{2011-02-17}
   s.description = %q{Will take all css in a page (either from linked stylesheet or from style tag) and will embed it in the style attribute for 
 each refered element taking selector specificity and declarator order.
 
@@ -18,7 +18,7 @@ Useful for html email: some clients (gmail, et all) won't render non inline styl
 * It takes into account selector specificity.}
   s.email = ["macarui@gmail.com"]
   s.extra_rdoc_files = ["History.txt", "Manifest.txt", "README.txt"]
-  s.files = ["History.txt", "Manifest.txt", "README.txt", "Rakefile", "example.rb", "lib/inline-style.rb", "lib/inline-style/rack/middleware.rb", "spec/as_middleware_spec.rb", "spec/css_inlining_spec.rb", "spec/fixtures/all.css", "spec/fixtures/boletin.html", "spec/fixtures/box-model.html", "spec/fixtures/inline.html", "spec/fixtures/none.css", "spec/fixtures/print.css", "spec/fixtures/selectors.html", "spec/fixtures/style.css", "spec/spec_helper.rb"]
+  s.files = ["History.txt", "Manifest.txt", "README.txt", "Rakefile", "example.rb", "inline-style.gemspec", "lib/inline-style.rb", "lib/inline-style/css_parsers.rb", "lib/inline-style/css_parsers/css_parser.rb", "lib/inline-style/css_parsers/csspool.rb", "lib/inline-style/mail/interceptor.rb", "lib/inline-style/rack/middleware.rb", "spec/as_middleware_spec.rb", "spec/css_inlining_spec.rb", "spec/css_parsers_spec.rb", "spec/factory_spec.rb", "spec/fixtures/all.css", "spec/fixtures/boletin.html", "spec/fixtures/box-model.html", "spec/fixtures/inline.html", "spec/fixtures/none.css", "spec/fixtures/print.css", "spec/fixtures/selectors.html", "spec/fixtures/style.css", "spec/interceptor_spec.rb", "spec/spec_helper.rb"]
   s.homepage = %q{http://github.com/maca/inline-style}
   s.rdoc_options = ["--main", "README.txt"]
   s.require_paths = ["lib"]
@@ -31,20 +31,17 @@ Useful for html email: some clients (gmail, et all) won't render non inline styl
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<nokogiri>, [">= 1.3.3"])
-      s.add_runtime_dependency(%q<maca-fork-csspool>, [">= 2.0.2"])
       s.add_development_dependency(%q<newgem>, [">= 1.5.3"])
       s.add_development_dependency(%q<mail>, [">= 0"])
       s.add_development_dependency(%q<hoe>, [">= 2.9.1"])
     else
       s.add_dependency(%q<nokogiri>, [">= 1.3.3"])
-      s.add_dependency(%q<maca-fork-csspool>, [">= 2.0.2"])
       s.add_dependency(%q<newgem>, [">= 1.5.3"])
       s.add_dependency(%q<mail>, [">= 0"])
       s.add_dependency(%q<hoe>, [">= 2.9.1"])
     end
   else
     s.add_dependency(%q<nokogiri>, [">= 1.3.3"])
-    s.add_dependency(%q<maca-fork-csspool>, [">= 2.0.2"])
     s.add_dependency(%q<newgem>, [">= 1.5.3"])
     s.add_dependency(%q<mail>, [">= 0"])
     s.add_dependency(%q<hoe>, [">= 2.9.1"])

--- a/lib/inline-style.rb
+++ b/lib/inline-style.rb
@@ -40,10 +40,10 @@ module InlineStyle
           path = node.css_path
           path << "##{ node['id'] }" if node['id']
           path << ".#{ node['class'].scan(/\S+/).join('.') }" if node['class']
-          
-          InlineStyle::CssParsers.parser.new("#{ path }{#{ node['style'] }}").each_rule_sets do |rule|
-            rule.each_selectors do |css_selector, declarations, specificity|
-              nodes[node].push [css_selector, declarations, specificity]
+
+          InlineStyle::CssParsers.parser.new("#{ path }{#{ node['style'] }}").each_rule_set do |rule|
+            rule.each_selector do |css_selector_inner, declarations_inner, specificity_inner|
+              nodes[node].push [css_selector_inner, declarations_inner, specificity_inner, css_selector_inner]
             end
           end
         end
@@ -51,7 +51,7 @@ module InlineStyle
     end
 
     nodes.each_pair do |node, style|
-      style = style.sort_by{ |(sel, dec, spe)| "#{ spe }%03d" % style.index([sel, dec, spe]) }
+      style = style.sort_by{ |(sel, dec, spe, orig)| "#{ spe }%03d" % style.index([sel, dec, spe, orig]) }
       sets  = style.partition{ |(sel, dec, spe, orig)| not /:\w+/ === orig  }
       
       sets.pop if not pseudo or sets.last.empty?

--- a/lib/inline-style/css_parsers.rb
+++ b/lib/inline-style/css_parsers.rb
@@ -12,7 +12,7 @@ module InlineStyle
 
     def self.parser
       return @parser if @parser
-      @parser_name = ENV['CSS_PARSER'] || :csspool unless @parser_name
+      @parser_name = ENV['CSS_PARSER'] || :css_parser unless @parser_name
       require "inline-style/css_parsers/#{@parser_name}"
       @parser = const_get(@parser_name.to_s.gsub(/(?:^|_)(.)/) { $1.upcase })
     end

--- a/lib/inline-style/css_parsers.rb
+++ b/lib/inline-style/css_parsers.rb
@@ -1,7 +1,7 @@
 module InlineStyle
 
   # A factory for returning a configured CSS parser. Defaults to
-  # :csspool if not specified. Will also use ENV['CSS_PARSER'].
+  # :css_parser if not specified. Will also use ENV['CSS_PARSER'].
   module CssParsers
 
     # Allows you to specify the CSS parser to use.

--- a/lib/inline-style/css_parsers.rb
+++ b/lib/inline-style/css_parsers.rb
@@ -1,0 +1,21 @@
+module InlineStyle
+
+  # A factory for returning a configured CSS parser. Defaults to
+  # :csspool if not specified. Will also use ENV['CSS_PARSER'].
+  module CssParsers
+
+    # Allows you to specify the CSS parser to use.
+    def self.parser=(parser)
+      @parser = nil
+      @parser_name = parser
+    end
+
+    def self.parser
+      return @parser if @parser
+      @parser_name = ENV['CSS_PARSER'] || :csspool unless @parser_name
+      require "inline-style/css_parsers/#{@parser_name}"
+      @parser = const_get(@parser_name.to_s.gsub(/(?:^|_)(.)/) { $1.upcase })
+    end
+
+  end
+end

--- a/lib/inline-style/css_parsers/css_parser.rb
+++ b/lib/inline-style/css_parsers/css_parser.rb
@@ -1,0 +1,56 @@
+require 'css_parser'
+
+module InlineStyle::CssParsers
+  class CssParser
+
+    def initialize(css_code)
+      @parser = ::CssParser::Parser.new
+      @parser.add_block! css_code
+    end
+
+    def each_rule_set(&blk)
+      @parser.each_rule_set do |rule_set|
+        yield Ruleset.new(rule_set)
+      end
+    end
+
+    class Ruleset
+
+      def initialize(ruleset)
+        @ruleset = ruleset
+      end
+
+      def each_selector
+        @ruleset.each_selector do |sel, dec, spe|
+          normalize_for_test! dec
+          yield sel, dec, spe
+        end
+      end
+
+      private
+
+      # To make testings work for both parsers we need to conform to
+      # csspool normalizing attributes. This means all numbers have a
+      # decimal place. It also means that urls do not have quotes.
+      #
+      # NOTE: This really doesn't have anything to do with the
+      # correctness of the parser. It just makes testing easier since
+      # each parser can run against the same tests.
+      def normalize_for_test!(dec)
+
+          # Give all numbers a decimal if they do not already have it
+          dec.gsub! '0;', '0.0;'
+          dec.gsub! ' 0 ', ' 0.0 '
+          dec.gsub! /([^\.0-9]\d+)px/, '\1.0px'
+          dec.gsub! /([^\.0-9]\d+)%/, '\1.0%'
+
+          # Remove any quotes in url()
+          dec.gsub! "url('", 'url('
+          dec.gsub! "')", ')'
+
+      end
+
+    end
+
+  end
+end

--- a/lib/inline-style/css_parsers/csspool.rb
+++ b/lib/inline-style/css_parsers/csspool.rb
@@ -1,0 +1,34 @@
+gem 'maca-fork-csspool'
+require 'csspool'
+
+module InlineStyle::CssParsers
+  class Csspool
+
+    def initialize(css_code)
+      @parser = CSSPool.CSS css_code
+    end
+
+    def each_rule_set
+      @parser.rule_sets.each do |rule_set|
+        yield Ruleset.new(rule_set)
+      end
+    end
+
+    class Ruleset
+
+      def initialize(ruleset)
+        @ruleset = ruleset
+      end
+
+      def each_selector(&blk)
+        @ruleset.selectors.each do |selector|
+          yield selector.to_s,
+            selector.declarations.map{ |d| d.to_s.squeeze(' ') }.join.strip,
+            selector.specificity.inject(0) {|t, s| t+s}
+        end
+      end
+
+    end
+
+  end
+end

--- a/spec/css_parsers_spec.rb
+++ b/spec/css_parsers_spec.rb
@@ -1,0 +1,55 @@
+require "#{ File.dirname __FILE__ }/spec_helper"
+require "#{ DIR }/../lib/inline-style/css_parsers/css_parser"
+require "#{ DIR }/../lib/inline-style/css_parsers/csspool"
+
+describe InlineStyle::CssParsers::CssParser do
+
+  it 'should wrap css_parser' do
+    rs_count = 0
+    sel_count = 0
+    selectors = %w(p b i)
+    decs = ['color: black;', 'color: black;', 'color: green; text-decoration: none;']
+    spes = [1, 1, 1]
+    p = InlineStyle::CssParsers::CssParser.new "p, b {color: black}\ni {color: green; text-decoration: none}"
+
+    p.each_rule_set do |rs|
+      rs_count += 1
+      rs.each_selector do |sel, dec, spe|
+        sel_count += 1
+        sel.should == selectors.shift
+        dec.should == decs.shift
+        spe.should == spes.shift
+      end
+    end
+
+    rs_count.should == 2
+    sel_count.should == 3
+  end
+
+end
+
+describe InlineStyle::CssParsers::Csspool do
+
+  it 'should wrap csspool' do
+    rs_count = 0
+    sel_count = 0
+    selectors = %w(p b i)
+    decs = ['color: black;', 'color: black;', 'color: green; text-decoration: none;']
+    spes = [1, 1, 1]
+    p = InlineStyle::CssParsers::Csspool.new "p, b {color: black}\ni {color: green; text-decoration: none}"
+
+    p.each_rule_set do |rs|
+      rs_count += 1
+      rs.each_selector do |sel, dec, spe|
+        sel_count += 1
+        sel.should == selectors.shift
+        dec.should == decs.shift
+        spe.should == spes.shift
+      end
+    end
+
+    rs_count.should == 2
+    sel_count.should == 3
+  end
+
+end

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -1,0 +1,38 @@
+require "#{ File.dirname __FILE__ }/spec_helper"
+
+describe InlineStyle::CssParsers do
+
+  before do
+    @orig_env = ENV['CSS_PARSER']
+    ENV['CSS_PARSER'] = nil
+    InlineStyle::CssParsers.parser = nil # Clear out any cached value
+  end
+  after do
+    ENV['CSS_PARSER'] = @orig_env
+    InlineStyle::CssParsers.parser = nil # Clear out any cached value
+  end
+
+  it 'should load csspool by default' do
+    InlineStyle::CssParsers.parser.name.
+    should == 'InlineStyle::CssParsers::Csspool'
+  end
+
+  it "should obey ENV['CSS_PARSER']" do
+    ENV['CSS_PARSER'] = 'css_parser'
+    InlineStyle::CssParsers.parser.name.
+    should == 'InlineStyle::CssParsers::CssParser'
+  end
+
+  it 'should be able to load csspool' do
+    InlineStyle::CssParsers.parser = :csspool
+    InlineStyle::CssParsers.parser.name.
+    should == 'InlineStyle::CssParsers::Csspool'
+  end
+
+  it 'should be able to load css_parser' do
+    InlineStyle::CssParsers.parser = :css_parser
+    InlineStyle::CssParsers.parser.name.
+    should == 'InlineStyle::CssParsers::CssParser'
+  end
+
+end

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -12,9 +12,9 @@ describe InlineStyle::CssParsers do
     InlineStyle::CssParsers.parser = nil # Clear out any cached value
   end
 
-  it 'should load csspool by default' do
+  it 'should load css_parser by default' do
     InlineStyle::CssParsers.parser.name.
-    should == 'InlineStyle::CssParsers::Csspool'
+    should == 'InlineStyle::CssParsers::CssParser'
   end
 
   it "should obey ENV['CSS_PARSER']" do

--- a/spec/fixtures/inline.html
+++ b/spec/fixtures/inline.html
@@ -96,7 +96,7 @@
     contacto <br style="margin: 0.0; padding: 0.0;"><a href="mailto:mail@host.org" style="margin: 0.0; padding: 0.0; color: #185d6b; font-weight: bold; font-size: 1.2em;">mail@host.org</a>
   </div>
   <div id="logos" style="margin: 0.0; padding: 0.0; width: 100.0%; margin-top: 40.0px; background-image: url(/images/boletines/Noviembre/logos_fondo.jpg);">
-    <img src="A" id="izq" alt="A" style="margin: 0.0; padding: 0.0; margin: 30.0px; float: left; padding: 10.0px; color: red;"><img src="B" id="der" alt="B" style="margin: 0.0; padding: 0.0; float: right;"><div class="clearer" style="margin: 0.0; padding: 0.0; clear: both;">
+    <img src="A" id="izq" alt="A" style="margin: 0.0; padding: 0.0; float: left; margin: 30.0px; padding: 10.0px; color: red;"><img src="B" id="der" alt="B" style="margin: 0.0; padding: 0.0; float: right;"><div class="clearer" style="margin: 0.0; padding: 0.0; clear: both;">
   </div>
 </div>
 


### PR DESCRIPTION
When using this on another project I discovered some bugs when an element already had an inline style. Also switched to css_parser being the default parser. Makes the pure Ruby solution the preferred. Also I have found that although csspool is feature-filled it doesn't handle semi-invalid CSS well because it does real parsing while CSSParser I think has looser definitions of CSS.
