### PR TITLE
Fixing location-based pseudo classes (like :first-child)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,11 +42,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  css_parser
   inline-style!
-  maca-fork-csspool
   mail
-  nokogiri
   rack
   rspec
   rspec-core

--- a/inline-style.gemspec
+++ b/inline-style.gemspec
@@ -4,7 +4,7 @@ require "inline-style/version"
 
 Gem::Specification.new do |s|
   s.name        = "inline-style"
-  s.version     = Inline::Style::VERSION
+  s.version     = InlineStyle::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Macario Ortega", "Eric Anderson"]
   s.email       = ["macarui@gmail.com"]

--- a/lib/inline-style.rb
+++ b/lib/inline-style.rb
@@ -1,11 +1,8 @@
 require 'nokogiri'
 require 'open-uri'
 
-require "#{ File.dirname( __FILE__ ) }/inline-style/css_parsers"
-require "#{ File.dirname( __FILE__ ) }/inline-style/rack/middleware"
-require "#{ File.dirname( __FILE__ ) }/inline-style/mail/interceptor"
+class InlineStyle
 
-module InlineStyle
   #   Options:
   #     +:stylesheets_path+
   #       Stylesheets root path, can also be a URL
@@ -16,22 +13,25 @@ module InlineStyle
   #       Defaults to false and should probably be left like that because at least Safari and Firefox don't seem to 
   #       comply with the specification for pseudo class style in the style attribute.
   def self.process html, opts = {}
-    stylesheets_path = opts[:stylesheets_path] || ''
-    pseudo           = opts[:pseudo] || false
-    
-    nokogiri_doc_given = Nokogiri::HTML::Document === html
-    html  = nokogiri_doc_given ? html : Nokogiri.HTML(html)
-    css   = extract_css html, stylesheets_path
+    new(html, opts).send :process
+  end
+
+  private
+
+  def initialize html, opts = {}
+    @html             = html
+    @stylesheets_path = opts[:stylesheets_path] || ''
+    @pseudo           = opts[:pseudo]
+  end
+
+  def process
     nodes = {}
 
     css.each_rule_set do |rule_set|
-      rule_set.each_selector do |css_selector, declarations, specificity|
-        orig_selector = css_selector.dup
-        css_selector = "#{ 'body ' unless /^body/ === css_selector }#{ css_selector.gsub /:.*/, '' }"
-        
-        html.css(css_selector).each do |node|
+      rule_set.each_selector do |selector|        
+        dom.css(selector.search).each do |node|
           nodes[node] ||= []
-          nodes[node].push [css_selector, declarations, specificity, orig_selector]
+          nodes[node].push selector
           
           next unless node['style']
           
@@ -40,44 +40,66 @@ module InlineStyle
           path << ".#{ node['class'].scan(/\S+/).join('.') }" if node['class']
 
           InlineStyle::CssParsers.parser.new("#{ path }{#{ node['style'] }}").each_rule_set do |rule|
-            rule.each_selector do |css_selector_inner, declarations_inner, specificity_inner|
-              nodes[node].push [css_selector_inner, declarations_inner, specificity_inner, css_selector_inner]
+            rule.each_selector do |selector_inner|
+              nodes[node].push selector_inner
             end
           end
         end
       end
     end
 
-    nodes.each_pair do |node, style|
-      style = style.sort_by{ |(sel, dec, spe, orig)| "#{ spe }%03d" % style.index([sel, dec, spe, orig]) }
-      sets  = style.partition{ |(sel, dec, spe, orig)| not /:\w+/ === orig  }
+    nodes.each_pair do |node, selectors|
+      selectors = selectors.sort_by{ |sel| "#{ sel.specificity }%03d" % selectors.index(sel) }
+      selectors = selectors.reject {|sel| not @pseudo and sel.pseudo?}
+      using_pseudo = selectors.any? &:pseudo?
       
-      sets.pop if not pseudo or sets.last.empty?
-      
-      node['style'] = sets.collect do |selectors|
-        index = sets.index selectors
-        
-        set   = selectors.map do |(css_selector, declarations, specificity, orig_selector)|
-          index == 0 ? declarations : "\n#{ orig_selector.gsub /\w(?=:)/, '' } {#{ declarations }}"
+      node['style'] = selectors.collect do |selector|
+        if using_pseudo && !selector.pseudo?
+          "{#{ selector.inline_declarations }}"
+        else
+          selector.inline_declarations
         end
-                     
-        index == 0 && sets.size > 1 ? "{#{ set }}" : set.collect(&:strip).join(' ')
-      end.join.strip
+      end.join(' ').strip
     end
     
-    nokogiri_doc_given ? html : html.to_s
+    if html_already_parsed?
+      @dom
+    else
+      @dom.to_s
+    end
   end
-  
-  # Returns CSSPool::Document
-  def self.extract_css html, stylesheets_path = ''
-    InlineStyle::CssParsers.parser.new html.css('style, link').collect { |e|
+
+  def dom
+    @dom ||= if html_already_parsed?
+      @html
+    else
+      Nokogiri.HTML @html
+    end
+  end
+
+  def html_already_parsed?
+    @html.respond_to? :css
+  end
+
+  # Returns parsed CSS
+  def css
+    @css ||= InlineStyle::CssParsers.parser.new dom.css('style, link').collect { |e|
       next unless e['media'].nil? || ['screen', 'all'].include?(e['media'])
       next(e.remove and e.content) if e.name == 'style'
       next unless e['rel'] == 'stylesheet'
       e.remove
       
-      uri = %r{^https?://} === e['href'] ? e['href'] : File.join(stylesheets_path, e['href'].sub(/\?\d+$/,''))
+      uri = if %r{^https?://} === e['href']
+        e['href']
+      else
+        File.join @stylesheets_path, e['href'].sub(/\?\d+$/,'')
+      end
       open(uri).read rescue nil
     }.join("\n")
   end
 end
+
+require "#{ File.dirname( __FILE__ ) }/inline-style/selector"
+require "#{ File.dirname( __FILE__ ) }/inline-style/css_parsers"
+require "#{ File.dirname( __FILE__ ) }/inline-style/rack/middleware"
+require "#{ File.dirname( __FILE__ ) }/inline-style/mail/interceptor"

--- a/lib/inline-style.rb
+++ b/lib/inline-style.rb
@@ -28,7 +28,7 @@ class InlineStyle
     nodes = {}
 
     css.each_rule_set do |rule_set|
-      rule_set.each_selector do |selector|        
+      rule_set.each_selector do |selector|
         dom.css(selector.search).each do |node|
           nodes[node] ||= []
           nodes[node].push selector

--- a/lib/inline-style/css_parsers.rb
+++ b/lib/inline-style/css_parsers.rb
@@ -1,21 +1,18 @@
-module InlineStyle
+# A factory for returning a configured CSS parser. Defaults to
+# :css_parser if not specified. Will also use ENV['CSS_PARSER'].
+module InlineStyle::CssParsers
 
-  # A factory for returning a configured CSS parser. Defaults to
-  # :css_parser if not specified. Will also use ENV['CSS_PARSER'].
-  module CssParsers
-
-    # Allows you to specify the CSS parser to use.
-    def self.parser=(parser)
-      @parser = nil
-      @parser_name = parser
-    end
-
-    def self.parser
-      return @parser if @parser
-      @parser_name = ENV['CSS_PARSER'] || :css_parser unless @parser_name
-      require "inline-style/css_parsers/#{@parser_name}"
-      @parser = const_get(@parser_name.to_s.gsub(/(?:^|_)(.)/) { $1.upcase })
-    end
-
+  # Allows you to specify the CSS parser to use.
+  def self.parser=(parser)
+    @parser = nil
+    @parser_name = parser
   end
+
+  def self.parser
+    return @parser if @parser
+    @parser_name = ENV['CSS_PARSER'] || :css_parser unless @parser_name
+    require "inline-style/css_parsers/#{@parser_name}"
+    @parser = const_get(@parser_name.to_s.gsub(/(?:^|_)(.)/) { $1.upcase })
+  end
+
 end

--- a/lib/inline-style/css_parsers/css_parser.rb
+++ b/lib/inline-style/css_parsers/css_parser.rb
@@ -23,7 +23,7 @@ module InlineStyle::CssParsers
       def each_selector
         @ruleset.each_selector do |sel, dec, spe|
           normalize_for_test! dec
-          yield sel, dec, spe
+          yield InlineStyle::Selector.new(sel, dec, spe)
         end
       end
 

--- a/lib/inline-style/css_parsers/csspool.rb
+++ b/lib/inline-style/css_parsers/csspool.rb
@@ -22,9 +22,9 @@ module InlineStyle::CssParsers
 
       def each_selector(&blk)
         @ruleset.selectors.each do |selector|
-          yield selector.to_s,
+          yield InlineStyle::Selector.new(selector.to_s,
             selector.declarations.map{ |d| d.to_s.squeeze(' ') }.join.strip,
-            selector.specificity.inject(0) {|t, s| t+s}
+            selector.specificity.inject(0) {|t, s| t+s})
         end
       end
 

--- a/lib/inline-style/mail/interceptor.rb
+++ b/lib/inline-style/mail/interceptor.rb
@@ -9,29 +9,27 @@
 #
 #   ActionMailer::Base.register_interceptor \
 #     InlineStyle::Mail::Interceptor.new(:stylesheets_path => 'public')
-module InlineStyle
-  module Mail
-    class Interceptor
-      # The mime types we should inline. Basically HTML and XHTML.
-      # If you have something else you can just push it onto the list
-      INLINE_MIME_TYPES = %w(text/html application/xhtml+xml)
+module InlineStyle::Mail
+  class Interceptor
+    # The mime types we should inline. Basically HTML and XHTML.
+    # If you have something else you can just push it onto the list
+    INLINE_MIME_TYPES = %w(text/html application/xhtml+xml)
 
-      # Save the options to later pass to InlineStyle.process
-      def initialize(options={})
-        @options = options
-      end
-
-      # Mail callback where we actually inline the styles
-      def delivering_email(part)
-        if part.multipart?
-          for part in part.parts
-            delivering_email part
-          end
-        elsif INLINE_MIME_TYPES.any? {|m| part.content_type.starts_with? m}
-          part.body = InlineStyle.process(part.body.to_s, @options)
-        end
-      end
-
+    # Save the options to later pass to InlineStyle.process
+    def initialize(options={})
+      @options = options
     end
+
+    # Mail callback where we actually inline the styles
+    def delivering_email(part)
+      if part.multipart?
+        for part in part.parts
+          delivering_email part
+        end
+      elsif INLINE_MIME_TYPES.any? {|m| part.content_type.starts_with? m}
+        part.body = InlineStyle.process(part.body.to_s, @options)
+      end
+    end
+
   end
 end

--- a/lib/inline-style/rack/middleware.rb
+++ b/lib/inline-style/rack/middleware.rb
@@ -1,41 +1,39 @@
-module InlineStyle
-  module Rack
-    class Middleware
-      #
-      #   Options:
-      #     +stylesheets_path+
-      #       Stylesheets root path or app's public directory where the stylesheets are to be found, defaults to
-      #       env['DOCUMENT_ROOT']
-      #     
-      #     +paths+
-      #       Limit processing to the passed absolute paths
-      #       Can be an array of strings or regular expressions, a single string or regular expression
-      #       If not passed will process output for every path.
-      #       Regexps and strings must comence with '/'
-      #
-      #     +pseudo+
-      #       If set to true will inline style for pseudo classes according to the W3C specification:
-      #       http://www.w3.org/TR/css-style-attr.
-      #       Defaults to false and should probably be left like that because at least Safari and Firefox don't seem to 
-      #       comply with the specification for pseudo class style in the style attribute.
-      #
-      def initialize app, opts = {}
-        @app   = app
-        @opts  = opts
-        @paths = /^(?:#{ [*opts[:paths]].join('|') })/
-      end
+module InlineStyle::Rack
+  class Middleware
+    #
+    #   Options:
+    #     +stylesheets_path+
+    #       Stylesheets root path or app's public directory where the stylesheets are to be found, defaults to
+    #       env['DOCUMENT_ROOT']
+    #     
+    #     +paths+
+    #       Limit processing to the passed absolute paths
+    #       Can be an array of strings or regular expressions, a single string or regular expression
+    #       If not passed will process output for every path.
+    #       Regexps and strings must comence with '/'
+    #
+    #     +pseudo+
+    #       If set to true will inline style for pseudo classes according to the W3C specification:
+    #       http://www.w3.org/TR/css-style-attr.
+    #       Defaults to false and should probably be left like that because at least Safari and Firefox don't seem to 
+    #       comply with the specification for pseudo class style in the style attribute.
+    #
+    def initialize app, opts = {}
+      @app   = app
+      @opts  = opts
+      @paths = /^(?:#{ [*opts[:paths]].join('|') })/
+    end
 
-      def call env
-        response = @app.call env
-        return response unless @paths === env['PATH_INFO']
-        
-        status, headers, content = response
-        response = ::Rack::Response.new '', status, headers
-        body     = content.respond_to?(:body) ? content.body : content
-        
-        response.write InlineStyle.process(body, {:stylesheets_path => env['DOCUMENT_ROOT']}.merge(@opts))
-        response.finish
-      end
+    def call env
+      response = @app.call env
+      return response unless @paths === env['PATH_INFO']
+      
+      status, headers, content = response
+      response = ::Rack::Response.new '', status, headers
+      body     = content.respond_to?(:body) ? content.body : content
+      
+      response.write InlineStyle.process(body, {:stylesheets_path => env['DOCUMENT_ROOT']}.merge(@opts))
+      response.finish
     end
   end
 end

--- a/lib/inline-style/selector.rb
+++ b/lib/inline-style/selector.rb
@@ -1,0 +1,27 @@
+# A simple abstraction of the data we get back from the parsers. CSSPool
+# actually already does this for us but CSSParser does not so we need
+# to create the abstraction ourselves.
+class InlineStyle::Selector < Struct.new :selector_text, :declarations, :specificity
+
+  # A slightly adjusted version of the selector_text that should be
+  # used for finding nodes.
+  def search
+    selector_text.gsub(/:.*/, '').tap {|s| s.insert(0, 'body ') unless s =~ /^body/}
+  end
+
+  # For the most part is just declarations unless a pseudo selector.
+  # Then it uses the inline pseudo declarations 
+  def inline_declarations
+    if pseudo?
+      "\n#{ selector_text.gsub /\w(?=:)/, '' } {#{ declarations }}"
+    else
+      declarations
+    end
+  end
+
+  # Is this selector using a pseudo class?
+  def pseudo?
+    selector_text =~ /:\w+/ 
+  end
+
+end

--- a/lib/inline-style/version.rb
+++ b/lib/inline-style/version.rb
@@ -1,5 +1,3 @@
-module Inline
-  module Style
-    VERSION = '0.4.6'  
-  end
+class InlineStyle
+  VERSION = '0.4.6'
 end

--- a/spec/css_inlining_spec.rb
+++ b/spec/css_inlining_spec.rb
@@ -34,6 +34,10 @@ describe InlineStyle do
     processed.css('a').first['style'].should =~ /\{/
   end
 
+  it 'should process location-based pseudo classes' do
+    @processed.at_css('#izq')['style'].should =~ /padding: 1.0px;/
+  end
+
   it 'should apply to #A #B' do
     @processed.css('#logos #der').first['style'].should =~ /float: right;/
   end

--- a/spec/css_parsers_spec.rb
+++ b/spec/css_parsers_spec.rb
@@ -14,11 +14,11 @@ describe InlineStyle::CssParsers::CssParser do
 
     p.each_rule_set do |rs|
       rs_count += 1
-      rs.each_selector do |sel, dec, spe|
+      rs.each_selector do |sel|
         sel_count += 1
-        sel.should == selectors.shift
-        dec.should == decs.shift
-        spe.should == spes.shift
+        sel.selector_text.should == selectors.shift
+        sel.declarations.should == decs.shift
+        sel.specificity.should == spes.shift
       end
     end
 
@@ -40,11 +40,11 @@ describe InlineStyle::CssParsers::Csspool do
 
     p.each_rule_set do |rs|
       rs_count += 1
-      rs.each_selector do |sel, dec, spe|
+      rs.each_selector do |sel|
         sel_count += 1
-        sel.should == selectors.shift
-        dec.should == decs.shift
-        spe.should == spes.shift
+        sel.selector_text.should == selectors.shift
+        sel.declarations.should == decs.shift
+        sel.specificity.should == spes.shift
       end
     end
 

--- a/spec/fixtures/boletin.html
+++ b/spec/fixtures/boletin.html
@@ -124,6 +124,10 @@ div#contacto a {
   background-image: url('/images/boletines/Noviembre/logos_fondo.jpg');
 }
 
+#logos img:first-child {
+  padding: 1px;
+}
+
 #izq {
     float: left;
 }

--- a/spec/fixtures/inline.html
+++ b/spec/fixtures/inline.html
@@ -96,7 +96,7 @@
     contacto <br style="margin: 0.0; padding: 0.0;"><a href="mailto:mail@host.org" style="margin: 0.0; padding: 0.0; color: #185d6b; font-weight: bold; font-size: 1.2em;">mail@host.org</a>
   </div>
   <div id="logos" style="margin: 0.0; padding: 0.0; width: 100.0%; margin-top: 40.0px; background-image: url(/images/boletines/Noviembre/logos_fondo.jpg);">
-    <img src="A" id="izq" alt="A" style="margin: 0.0; padding: 0.0; float: left; margin: 30.0px; padding: 10.0px; color: red;"><img src="B" id="der" alt="B" style="margin: 0.0; padding: 0.0; float: right;"><div class="clearer" style="margin: 0.0; padding: 0.0; clear: both;">
+    <img src="A" id="izq" alt="A" style="margin: 0.0; padding: 0.0; float: left; margin: 30.0px; padding: 10.0px; color: red; padding: 1.0px;"><img src="B" id="der" alt="B" style="margin: 0.0; padding: 0.0; float: right;"><div class="clearer" style="margin: 0.0; padding: 0.0; clear: both;">
   </div>
 </div>
 


### PR DESCRIPTION
The first commit is a big patch but purely a re-factor. Adding the pluggable CSS parser made the code much more ugly because we lost the "Selector" abstraction from CSSPool and replaced it with an array of attributes. The first patch adds that abstraction back with a simple struct. It also re-factors various other aspects of the code to try to make the purpose more obvious.

It should be the same basic logic as you had before and the tests still pass. It is just cleans things back up a bit after the pluggable parsers had made things less readable that I would like.

The second patch is really my purpose to doing the re-factor. There were some bugs in the pseudo-class handling for things like :first-child. My commit has more details on the bugs. The re-factor made fixing the bugs much easier.
