### PR TITLE
Slight tweak to gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,14 +3,15 @@ PATH
   specs:
     inline-style (0.4.6)
       css_parser
-      maca-fork-csspool
       nokogiri
 
 GEM
   remote: http://rubygems.org/
   specs:
     activesupport (3.0.4)
-    css_parser (1.1.5)
+    addressable (2.2.6)
+    css_parser (1.2.5)
+      addressable
     diff-lcs (1.1.2)
     ffi (1.0.6)
       rake (>= 0.8.7)
@@ -23,7 +24,7 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     mime-types (1.16)
-    nokogiri (1.4.4)
+    nokogiri (1.5.0)
     polyglot (0.3.1)
     rack (1.2.1)
     rake (0.8.7)
@@ -43,6 +44,7 @@ PLATFORMS
 
 DEPENDENCIES
   inline-style!
+  maca-fork-csspool
   mail
   rack
   rspec

--- a/inline-style.gemspec
+++ b/inline-style.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack'
   s.add_development_dependency 'rspec-core'
   s.add_development_dependency 'mail'
+  s.add_development_dependency 'maca-fork-csspool'
 
   s.add_dependency 'nokogiri'
   s.add_dependency 'css_parser'
-  s.add_dependency 'maca-fork-csspool'
 end


### PR DESCRIPTION
Not requiring CSSPool as a dependency makes this library easier to install on a machine. Here is a patch to make CSSPool optional. Of course if a user does require CSSPool on their own project it should still use that over CSSParser.
