### PR TITLE
transfer content encoding and non-ascii mail

### DIFF
--- a/lib/inline-style/mail-interceptor.rb
+++ b/lib/inline-style/mail-interceptor.rb
@@ -29,6 +29,7 @@ module InlineStyle::Mail
         end
       elsif INLINE_MIME_TYPES.any? {|m| part.content_type.starts_with? m}
         part.body = InlineStyle.process(part.body.to_s, @options)
+        part.content_transfer_encoding = nil
       end
     end
 


### PR DESCRIPTION
Hello,

We encountered an issue when using the mail interceptor and sending japanese mime-mail.

Ultimately the content_transfer_encoding would get set to quoted-printable, which would mess the final delivery.
I don't understand at which stage this happened (inside Mail) but a possible fix is to reset it in mail-interceptor.rb.

Anyway, I'll leave it to your discretion.  

Thanks
