### PR TITLE
NoMethodError: undefined method `starts_with?' for nil:NilClass

### DIFF
--- a/lib/inline-style/mail-interceptor.rb
+++ b/lib/inline-style/mail-interceptor.rb
@@ -27,7 +27,7 @@ module InlineStyle::Mail
         for part in part.parts
           delivering_email part
         end
-      elsif INLINE_MIME_TYPES.any? {|m| part.content_type.starts_with? m}
+      elsif INLINE_MIME_TYPES.any? {|m| part.content_type && part.content_type.starts_with?(m)}
         part.body = InlineStyle.process(part.body.to_s, @options)
         part.content_transfer_encoding = nil
       end


### PR DESCRIPTION
The error occurs when using Pony.

``` ruby
    Pony.mail({
      :to => 'email@domain.com',
      :from => 'noreply@domain.com',
      :subject => "Testing",
      :body => "This is just a test. Ignore it :)",
      :via => :smtp,
      :via_options => {
        :address              => 'smtp.gmail.com',
        :port                 => '587',
        :enable_starttls_auto => true,
        :user_name            => 'someone@gmail.com',
        :password             => 'very_secret',
        :authentication       => :plain
      }
    })
```

Just making sure `part.content_type` exists before calling `.starts_with?(m)`
